### PR TITLE
DM-40228: Configuration improvements

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -12,10 +12,12 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: '3.10'
+          python-version: "3.10"
 
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        run: |
+          python -m pip install -U pip
+          python -m pip install -r requirements.txt
 
       - name: Check links
         run: make linkcheck

--- a/conf.py
+++ b/conf.py
@@ -2,16 +2,6 @@
 
 from documenteer.conf.guide import *
 
-html_theme = "pydata_sphinx_theme"
-
-exclude_patterns = [
-    r"_build",
-    r"README.rst",
-    r"README.md",
-    r".venv",
-    r"venv",
-    r"requirements.txt",
-    r".github",
-    r".tox",
+exclude_patterns.extend([
     r"project/templates/template-folder",
-]
+])

--- a/data-products-dp0-3/data-simulation-dp0-3.rst
+++ b/data-products-dp0-3/data-simulation-dp0-3.rst
@@ -67,16 +67,16 @@ DP0.3 Flags
 
 As part of the absolute magnitude fitting process, let's define some flags for failure cases. These will be bitwise flags, so that the combinations of multiple flags are unique. 
 
-- Success! `FLAG = 0` 
-- Orbit fitting failure `FLAG = 1`: the diaSource detections do not fit a sensible orbit for a moving object (eg unusually high chi2/dof) 
+- Success! ``FLAG = 0``
+- Orbit fitting failure ``FLAG = 1``: the diaSource detections do not fit a sensible orbit for a moving object (eg unusually high chi2/dof) 
 - $H_u$ fit failure ``FLAG = 2`` : the u band absolute magnitude fit failed due to poor phase coverage or not enough data
 - $H_g$ fit failure ``FLAG = 4`` : the g band absolute magnitude fit failed due to poor phase coverage or not enough data
 - $H_r$ fit failure ``FLAG = 8`` : the r band absolute magnitude fit failed due to poor phase coverage or not enough data
 - $H_i$ fit failure ``FLAG = 16`` : the i band absolute magnitude fit failed due to poor phase coverage or not enough data
 - $H_z$ fit failure ``FLAG = 32`` : the z band absolute magnitude fit failed due to poor phase coverage or not enough data
 - $H_y$ fit failure ``FLAG = 64`` : the y band absolute magnitude fit failed due to poor phase coverage or not enough data
-- Linking failure: ``FLAG = 2048`` : the detections in diaSource were not successfully linked. Note that this will only exist for simulated objects, as a real object that is not linked will not be in `SSObject`! This is being simulated using `difi <https://github.com/moeyensj/difi/tree/main>`_.
+- Linking failure: ``FLAG = 2048`` : the detections in diaSource were not successfully linked. Note that this will only exist for simulated objects, as a real object that is not linked will not be in ``SSObject``! This is being simulated using `difi <https://github.com/moeyensj/difi/tree/main>`_.
 
-Example: an object whose photometry failed in u and y band will have `FLAG = 66` (in binary, `1000010`). 
+Example: an object whose photometry failed in u and y band will have ``FLAG = 66`` (in binary, ``1000010``). 
 
 Note that ``bool(flag & reference)`` is ``True`` if ``reference`` is part of the ``flag``. So, for example, ``bool(66 & 64) = True`` and ``bool(66 & 4) = False``.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 documenteer[guide]
-lsst_sphinx_bootstrap_theme


### PR DESCRIPTION
This PR is an attempt to fix the build issue (see [Slack](https://lsstc.slack.com/archives/C2B6DQBAL/p1690517764186069)) where apparent non-unicode characters in the site were crashing the build under Sphinx 7. A temporary fix seemed by be pinning Sphinx < 7, and this is done in Documenteer 0.8.4. However, Sphinx 7 was still be installed in some CI runs. To try to fix this, I'm ensuring pip is updated before updating dependencies.

Additionally, I made some small configuration fixes to ensure the DP0.3 docs use configurations from Documenteer rather than unnecessarily shadowing them.

In `data-simulation-dp0-3.rst` I fixed some build warnings related to API links not resolving — use double backticks for literals; single back tickets is an API linking
syntax.