### PR TITLE
Tickets/preops 3608

### DIFF
--- a/tutorials-dp0-3/portal-dp0-3-1.rst
+++ b/tutorials-dp0-3/portal-dp0-3-1.rst
@@ -52,8 +52,9 @@ Their contents are described in the :ref:`DP0-3-Data-Products-DPDD`.
 In Rubin Operations, these tables would be constantly changing, updated every day with the results of the previous night's observations. 
 However, for DP0.3, static catalogs have been simulated.  
 
-This tutorial focuses on the first two tables, ``MPCORB`` and ``SSObject``, and 
-:ref:`Tutorials-Examples-DP0-3-Portal-2` will focus on ``SSSource`` and ``DiaSource``.
+This tutorial focuses on the first two tables, ``MPCORB`` and ``SSObject`` and it will explore these tables individually.  The table joins will be demonstrated in 
+:ref:`Tutorials-Examples-DP0-3-Portal-2` which will focus on ``SSSource`` and ``DiaSource`` tables.  That tutorial will illustrate, among others, how to extract and plot the magnitude, 
+the heliocentric, and the topocentric position of an object vs. time.  
 
 
 The ``MPCORB`` table

--- a/tutorials-dp0-3/portal-dp0-3-1.rst
+++ b/tutorials-dp0-3/portal-dp0-3-1.rst
@@ -98,7 +98,7 @@ the ``SSObjects`` contains the Rubin-measured properties such as phase curve fit
 
 Note that no artifacts or spurious difference-image sources have been injected into the DP0.3 catalogs.
 
-**Absolute magnitudes:** For Solar System objects, absolute magnitudes are defined to be for an object 1 AU from the Sun and 1 AU 
+**Absolute magnitudes:** For Solar System objects, absolute magnitudes are defined to be for an object at a distance 1 au from the Sun and 1 au 
 from the observer, and at a phase angle (the angle Sun-object-Earth) of 0 degrees.
 Absolute magnitudes are derived by correcting for distance, fitting a function to the relationship between 
 absolute magnitude and phase, and evaluating the function at a phase of 0 deg.
@@ -149,7 +149,7 @@ automatically updates to display the columns of the ``MPCORB`` table.
 
     The Portal interface is prepared to query the ``MPCORB`` table.
 
-1.4. Set up a query to retrieve the eccentricity, inclination, and absolution magnitude H for 
+1.4. Set up a query to retrieve the eccentricity, inclination, and absolute magnitude H for 
 50000 bright objects in the ``MPCORB`` table.
 First, click the selection box next to each column name to be returned: 
 eccentricity (``e``), inclination (``incl``), and absolute magnitude H (``mpcH``).
@@ -276,7 +276,7 @@ Comparing this to the size of the ``MPCORB`` table is left as an exercise for th
 
 2.4. As the maximum value of the ``ssObjectId`` is ``9223370430250665087``, a random subset of ``SSObjects`` 
 that contains no more than 3% of the total number (about 120,000) can be returned by applying a constraint that 
-``ssObjectId`` must be greater than ``8660000000000000000`` (i.e., because :math:`922 - 0.06 \times 922 \approx 866`).
+``ssObjectId`` must be greater than ``8660000000000000000`` (i.e., because 922 - 0.06 * 922 is roughly 866).
 
 2.5. As in step 1.11 above, delete the results of this query and return to the Portal's search interface.
 Clear the past query from the ADQL box.
@@ -325,7 +325,7 @@ Under "Chart Options", set the "X Label", "Y Label", "X Min", "X Max", "Y Min", 
     The color-color diagram for a random subset of ``SSObjects``.
 
 
-2.10. View the plot, and notice that there are two populations of colors in the simulation.
+2.10. View the plot, and notice that there are two sets of object colors in the simulation.
 This is not the case for real Solar System objects.
 These plots will look very different in the future, when they are made with real Rubin data.
 Adjusting the plot parameters is left as an exercise for the learner.

--- a/tutorials-dp0-3/portal-dp0-3-2.rst
+++ b/tutorials-dp0-3/portal-dp0-3-2.rst
@@ -33,7 +33,7 @@ Introduction
 ============
 
 This tutorial is a direct sequel to Portal tutorial 01: Introduction to DP0.3: the ``MPCORB`` and ``SSObject`` tables.
-Those two tables contain derived parameters for individial simulated Solar System objects.
+Those two tables contain derived parameters for individual simulated Solar System objects.
 
 This tutorial focuses on the DP0.3 ``SSSource`` and ``DiaSource`` tables, which contain measured and derived
 values for individial simulated Solar System objects on a per-observation basis.  

--- a/tutorials-dp0-3/portal-dp0-3-2.rst
+++ b/tutorials-dp0-3/portal-dp0-3-2.rst
@@ -36,7 +36,7 @@ This tutorial is a direct sequel to Portal tutorial 01: Introduction to DP0.3: t
 Those two tables contain derived parameters for individual simulated Solar System objects.
 
 This tutorial focuses on the DP0.3 ``SSSource`` and ``DiaSource`` tables, which contain measured and derived
-values for individial simulated Solar System objects on a per-observation basis.  
+values for individial simulated Solar System objects on a per-observation basis.  Note that there are two separate DP0.3 catalogs, dp03_catalogs_1yr and dp03_catalogs_10yr, respectively. This tutorial uses the tables in the catalog resulting from the 10-year simulation.
 
 
 The ``SSSource`` table
@@ -152,7 +152,9 @@ of the object at the time of every simulated LSST observation from the ``SSSourc
 2.2. View the default results view, which plots the sun-centered orbit of ``heliocentricY`` versus ``heliocentricX``.
 Click on the plot settings icon and in the pop-up window, select "Chart Options" and then add a grid
 to the x and y axis to more easily identify the Sun's location at (0, 0).
-Click "Apply" and "Close".
+Click "Apply" and "Close".  
+
+Note that the defalt axis labels here use the "AU" description for the distance in astronomical units.  The official, IAU-sanctioned abbreviation of an astronomical unit is "au" (lower case), not "AU."  If you plan to use those (or equivalent) plots for publication, you need to edit the lables accordingly by clicking on the "Chart Options" for each plot.  
 
 .. figure:: /_static/portal_tut02_step02a.png
     :width: 400

--- a/tutorials-dp0-3/portal-dp0-3-2.rst
+++ b/tutorials-dp0-3/portal-dp0-3-2.rst
@@ -23,7 +23,7 @@
 
 **Contact authors:** Melissa Graham and Greg Madejski
 
-**Last verified to run:** Thu July 27 2023
+**Last verified to run:** Fri Aug 4 2023
 
 **Targeted learning level:** beginner
 
@@ -36,7 +36,7 @@ This tutorial is a direct sequel to Portal tutorial 01: Introduction to DP0.3: t
 Those two tables contain derived parameters for individial simulated Solar System objects.
 
 This tutorial focuses on the DP0.3 ``SSSource`` and ``DiaSource`` tables, which contain measured and derived
-values for individial simulated Solar System objects on a per-observation basis.
+values for individial simulated Solar System objects on a per-observation basis.  
 
 
 The ``SSSource`` table
@@ -79,9 +79,9 @@ TAP and ADQL
 The DP0.3 data sets are available via the Table Access Protocol (TAP) service via the Portal Aspect,
 and can be queried via either the "UI Assisted" table interface, 
 or via the ADQL (Astronomical Data Query Language) interface.
-This tutorial assumes completion of Portal Tutorial 01 and only demonstrates
-the ADQL interface.
-ADQL is similar to SQL (Structured Query Langage).
+This tutorial assumes completion of Portal Tutorial 01 and only demonstrates the ADQL interface.  
+It also llustrates how to perform table joins.  
+ADQL is similar to SQL (Structured Query Langage).  
 The `documentation for ADQL <http://www.ivoa.net/documents/latest/ADQL.html>`_ includes more information about syntax and keywords.
 
 

--- a/tutorials-dp0-3/portal-dp0-3-2.rst
+++ b/tutorials-dp0-3/portal-dp0-3-2.rst
@@ -154,7 +154,10 @@ Click on the plot settings icon and in the pop-up window, select "Chart Options"
 to the x and y axis to more easily identify the Sun's location at (0, 0).
 Click "Apply" and "Close".  
 
-Note that the defalt axis labels here use the "AU" description for the distance in astronomical units.  The official, IAU-sanctioned abbreviation of an astronomical unit is "au" (lower case), not "AU."  If you plan to use those (or equivalent) plots for publication, you need to edit the lables accordingly by clicking on the "Chart Options" for each plot.  
+Note that the defalt axis labels here use the "AU" description for the distance in astronomical units.  
+The official, IAU-sanctioned abbreviation of an astronomical unit is "au" (lower case), not "AU."  
+If you are interested in the details - you can check out the article on "Astronomical unit" on Wikipedia.  
+If you plan to use those (or equivalent) plots for publication, you need to edit the lables accordingly by clicking on the "Chart Options" for each plot.  
 
 .. figure:: /_static/portal_tut02_step02a.png
     :width: 400


### PR DESCRIPTION
I think I incorporated all points suggested by Melissa (from Meg) in her request in PREOPS-3608 in both Portal tutorials.  There is one outstanding minor issue in the Portal tutorial 02:  the default axis labels in Step 2.2 and 2.4 have Astronomical Units as AU, not au.  We could presumably change the axis labels by hand in the screenshots, if you think it is essential.  Or, we can add it as an exercise for the learner, along the lines:  "IAU declared that the symbol for the Astronomical Unit is 'au' and not 'AU.'  The default axis labels in the plots in Sections 2.2 and 2.4 state 'AU.'  Use the 'chart options and tools' icon for the plots (two gears) to modify the axis labels to be compliant with the current standards."  