### PR TITLE
Tickets/preops 3615

### DIFF
--- a/data-products-dp0-3/table-access-and-queries.rst
+++ b/data-products-dp0-3/table-access-and-queries.rst
@@ -135,6 +135,8 @@ table and stored in a ``df_uniqueObj`` table from a previous query.
     from lsst.rsp import get_tap_service, retrieve_query
     service = get_tap_service()
 
+    sId_list = [-9222537907249304995, -9222483995821535577, -9221971933016733299]
+
     query = """SELECT dia.ssObjectId, dia.diaSourceId, dia.mag,
     dia.magErr, dia.band, dia.midPointMjdTai,
     sss.phaseAngle, sss.topocentricDist, sss.heliocentricDist
@@ -143,12 +145,9 @@ table and stored in a ``df_uniqueObj`` table from a previous query.
     ON dia.diaSourceId = sss.diaSourceId
     WHERE dia.ssObjectId
     IN {}
-    """.format(tuple(df_uniqueObj['ssObjectId']))
+    """.format(tuple(sId_list))
 
     results = service.search(query).to_table()
-
-
-A relevent example for DP0.2 can be found `here <https://dp0-2.lsst.io/data-access-analysis-tools/adql-recipes.html#individual-objects>`__. 
 
 
 Non-random subsets

--- a/data-products-dp0-3/table-access-and-queries.rst
+++ b/data-products-dp0-3/table-access-and-queries.rst
@@ -124,12 +124,11 @@ Advice for passing an existing list to a new query
 ~~~~~~~~~~~
 
 LSST Query Services (Qserv) do not support subqueries. Thus, using subqueries are **not recommended** 
-although DP0.3 is not hosted on Qserv, but on the Rubin Science Platform (RSP). Instead, when having 
-a list of objects in hand either from a previous query or a user-provided catalog, the list, formatted 
-as a python tuple, can be passed to a new query for table joins. The example query below is to retrieve 
-information about individual observations from the ``DiaSource`` and ``SSSource`` tables for indivdual 
-unique objects selected from the ``SSObject`` table and stored in a ``df_uniqueObj`` table from a previous 
-query.
+although DP0.3 is not hosted on Qserv. Instead, when having a list of objects in hand either from a 
+previous query or a user-provided catalog, the list, formatted as a python tuple, can be passed to a 
+new query for table joins. The example query below is to retrieve information about individual observations 
+from the ``DiaSource`` and ``SSSource`` tables for indivdual unique objects selected from the ``SSObject`` 
+table and stored in a ``df_uniqueObj`` table from a previous query.
 
 .. code-block:: python
 

--- a/data-products-dp0-3/table-access-and-queries.rst
+++ b/data-products-dp0-3/table-access-and-queries.rst
@@ -121,9 +121,9 @@ be larger than expected, and take a long time to execute.
 .. _DP0-3-Table-Access-ADQL-passing-list:
 
 Advice for passing an existing list to a new query
-~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-LSST Query Services (Qserv) do not support subqueries. Thus, using subqueries are **not recommended** 
+LSST Query Services (Qserv) do not support subqueries. Thus, using subqueries is **not recommended** 
 although DP0.3 is not hosted on Qserv. Instead, when having a list of objects in hand either from a 
 previous query or a user-provided catalog, the list, formatted as a python tuple, can be passed to a 
 new query for table joins. The example query below is to retrieve information about individual observations 

--- a/data-products-dp0-3/table-access-and-queries.rst
+++ b/data-products-dp0-3/table-access-and-queries.rst
@@ -127,8 +127,9 @@ LSST Query Services (Qserv) do not support subqueries. Thus, using subqueries ar
 although DP0.3 is not hosted on Qserv, but on the Rubin Science Platform (RSP). Instead, when having 
 a list of objects in hand either from a previous query or a user-provided catalog, the list, formatted 
 as a python tuple, can be passed to a new query for table joins. The example query below is to retrieve 
-information about individual observations from the ``DiaSource`` and ``SSSource`` tables for each unique 
-object selected from the ``SSObject`` table in a previous query (df_uniqueObj['ssObjectId']).
+information about individual observations from the ``DiaSource`` and ``SSSource`` tables for indivdual 
+unique objects selected from the ``SSObject`` table and stored in a ``df_uniqueObj`` table from a previous 
+query.
 
 .. code-block:: python
 

--- a/data-products-dp0-3/table-access-and-queries.rst
+++ b/data-products-dp0-3/table-access-and-queries.rst
@@ -120,8 +120,8 @@ be larger than expected, and take a long time to execute.
 
 .. _DP0-3-Table-Access-ADQL-passing-list:
 
-Advice for passing a list to a query
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Query a list of objects
+~~~~~~~~~~~~~~~~~~~~~~~
 
 LSST Query Services (Qserv) do not support subqueries. 
 Thus, using subqueries is **not recommended** although DP0.3 is not hosted on Qserv. 

--- a/data-products-dp0-3/table-access-and-queries.rst
+++ b/data-products-dp0-3/table-access-and-queries.rst
@@ -125,11 +125,13 @@ Advice for passing a list to a query
 
 LSST Query Services (Qserv) do not support subqueries. 
 Thus, using subqueries is **not recommended** although DP0.3 is not hosted on Qserv. 
+
 Instead, when having a list of objects in hand either from a previous query or a user-provided catalog,
 the list, formatted as a python tuple, can be passed to a new query for table joins. 
 The example query below is to retrieve information about individual observations from the ``DiaSource`` 
 and ``SSSource`` tables for indivdual unique objects selected from the ``SSObject`` table and stored 
 in ``sId_list`` from a previous query. 
+
 The example uses only three objects, but the list can be relatively long (verified up to 50,000).
 
 

--- a/data-products-dp0-3/table-access-and-queries.rst
+++ b/data-products-dp0-3/table-access-and-queries.rst
@@ -150,8 +150,6 @@ query.
 
 
 A relevent example for DP0.2 can be found `here <https://dp0-2.lsst.io/data-access-analysis-tools/adql-recipes.html#individual-objects>`__. 
-Refer `DP0.2 ADQL Recipes <https://dp0-2.lsst.io/data-access-analysis-tools/adql-recipes.html>`__ 
-for more general ADQL advice.
 
 
 Non-random subsets

--- a/data-products-dp0-3/table-access-and-queries.rst
+++ b/data-products-dp0-3/table-access-and-queries.rst
@@ -120,20 +120,23 @@ be larger than expected, and take a long time to execute.
 
 .. _DP0-3-Table-Access-ADQL-passing-list:
 
-Advice for passing an existing list to a new query
+Advice for passing a list to a query
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-LSST Query Services (Qserv) do not support subqueries. Thus, using subqueries is **not recommended** 
-although DP0.3 is not hosted on Qserv. Instead, when having a list of objects in hand either from a 
-previous query or a user-provided catalog, the list, formatted as a python tuple, can be passed to a 
-new query for table joins. The example query below is to retrieve information about individual observations 
-from the ``DiaSource`` and ``SSSource`` tables for indivdual unique objects selected from the ``SSObject`` 
-table and stored in a ``df_uniqueObj`` table from a previous query.
+LSST Query Services (Qserv) do not support subqueries. 
+Thus, using subqueries is **not recommended** although DP0.3 is not hosted on Qserv. 
+Instead, when having a list of objects in hand either from a previous query or a user-provided catalog,
+the list, formatted as a python tuple, can be passed to a new query for table joins. 
+The example query below is to retrieve information about individual observations from the ``DiaSource`` 
+and ``SSSource`` tables for indivdual unique objects selected from the ``SSObject`` table and stored 
+in ``sId_list`` from a previous query. 
+The example uses only three objects, but the list can be relatively long (verified up to 50,000).
+
 
 .. code-block:: python
 
     from lsst.rsp import get_tap_service, retrieve_query
-    service = get_tap_service()
+    service = get_tap_service("ssotap")
 
     sId_list = [-9222537907249304995, -9222483995821535577, -9221971933016733299]
 
@@ -148,6 +151,8 @@ table and stored in a ``df_uniqueObj`` table from a previous query.
     """.format(tuple(sId_list))
 
     results = service.search(query).to_table()
+
+This returns a ``results`` table with 1915 rows; each of three unique objects has 597, 572, and 746 rows, respectively.
 
 
 Non-random subsets

--- a/data-products-dp0-3/table-access-and-queries.rst
+++ b/data-products-dp0-3/table-access-and-queries.rst
@@ -120,7 +120,7 @@ be larger than expected, and take a long time to execute.
 
 .. _DP0-3-Table-Access-ADQL-passing-list:
 
-Advice for passing an existing object list to a new query
+Advice for passing an existing list to a new query
 ~~~~~~~~~~~
 
 LSST Query Services (Qserv) do not support subqueries. Thus, using subqueries are **not recommended** 
@@ -128,7 +128,7 @@ although DP0.3 is not hosted on Qserv, but on the Rubin Science Platform (RSP). 
 a list of objects in hand either from a previous query or a user-provided catalog, the list, formatted 
 as a python tuple, can be passed to a new query for table joins. The example query below is to retrieve 
 information about individual observations from the ``DiaSource`` and ``SSSource`` tables for each unique 
-object selected from the ``SSObject`` table in a previous query.
+object selected from the ``SSObject`` table in a previous query (df_uniqueObj['ssObjectId']).
 
 .. code-block:: python
 


### PR DESCRIPTION
Add advice about passing lists with table joins for DP0.3. Note that while subqueries are possible for DP0.3, they're not recommended because subqueries are not supported in Qserv-hosted databases.