### PR TITLE
Update data-simulation-dp0-3.rst

### DIFF
--- a/data-products-dp0-3/data-simulation-dp0-3.rst
+++ b/data-products-dp0-3/data-simulation-dp0-3.rst
@@ -186,4 +186,12 @@ and they do not have a distribution of absolute H magnitudes (they are all brigh
 There are many more ISO and LPC objects in the simulation than the LSST is projected to observe, by orders of magnitude (only a few are expected).
 This is not exactly an issue: these populations were inflated on purpose so that a diversity of properties could be simulated.
 
-
+**Small biases in the reported PSF magnidues.**
+A small bias (roughly 0.02 mag) was identified in the slope parameter `G` (i.e., measured value - truth value of G) in all *griz* bands. 
+Also, offsets between the intrinsic absolute magnitude in `V` band and recovered absolute magnitude in the LSST filters were found to be 
+larger than listed in the filter-conversion table above (Table 1). Section 4 in the notebook tutorial 
+`DP03_04b <https://github.com/rubin-dp0/tutorial-notebooks/blob/main/DP03_04b_Advanced_Phase_Curve_Modeling.ipynb>`_ 
+describes these two biases. The DP0.3 simulation team found out that this is because the DP0.3 catalogs reported standard point-spread function (PSF)
+magnitudes without considering the apparent motion of solar system objecst. Moving objects appear in an image as trailed sources, resulting in 
+underestimation of the source's true flux as well as lower photometric signal-to-noise ratio (S/N) when conducting standard PSF photometry. 
+Once object trailing is taken into account in photometry, these biases disappear and will be fixed in subsequent releases. 


### PR DESCRIPTION
Add information about known biases and object trailing in photometry as an explanation.